### PR TITLE
Do not normalize keys

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,2 +1,4 @@
 parameters:
     ignoreErrors:
+        - '#Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\NodeParentInterface::scalarNode\(\)#'
+        - '#Calling method scalarNode\(\) on possibly null value of type Symfony\\Component\\Config\\Definition\\Builder\\NodeParentInterface\|null#'

--- a/src/Config/BaseConfigDefinition.php
+++ b/src/Config/BaseConfigDefinition.php
@@ -37,6 +37,7 @@ class BaseConfigDefinition implements ConfigurationInterface
         $builder = new TreeBuilder();
         /** @var ArrayNodeDefinition $parametersNode */
         $parametersNode = $builder->root('parameters');
+        $parametersNode->normalizeKeys(false);
         return $parametersNode;
     }
 

--- a/src/Config/BaseConfigDefinition.php
+++ b/src/Config/BaseConfigDefinition.php
@@ -48,6 +48,7 @@ class BaseConfigDefinition implements ConfigurationInterface
         /** @var ArrayNodeDefinition $rootNode */
         $rootNode = $treeBuilder->root('root');
         $rootNode->ignoreExtraKeys(false);
+        $rootNode->normalizeKeys(false);
 
         // @formatter:off
         $rootNode

--- a/tests/Config/BaseConfigDefinitionTest.php
+++ b/tests/Config/BaseConfigDefinitionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\Component\Tests\Config;
+
+use Keboola\Component\Config\BaseConfig;
+use Keboola\Component\Config\BaseConfigDefinition;
+use PHPUnit\Framework\TestCase;
+
+class BaseConfigDefinitionTest extends TestCase
+{
+    public function testConfigDefinitionDoesNotTouchKeys(): void
+    {
+        $definition = new BaseConfigDefinition();
+        $config = new BaseConfig([
+            'dash-key' => 'dash-value',
+            'underscore_key' => 'underscore_value',
+            'dot.key' => 'dot.value',
+            'slash/key' => 'slash/value',
+        ], $definition);
+
+        $this->assertSame('dash-value', $config->getValue(['dash-key']));
+        $this->assertSame('underscore_value', $config->getValue(['underscore_key']));
+        $this->assertSame('dot.value', $config->getValue(['dot.key']));
+        $this->assertSame('slash/value', $config->getValue(['slash/key']));
+    }
+}


### PR DESCRIPTION
Fixes #40. 

Unfortunately you can't disable normalization globally. You need to do it per-array-node basis. 

I tried to work around this by making it a deprecation error when you use dash-separated key in #42. 