### PR TITLE
Make php-component 7.3 ready

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ sudo: false
 language: php
 
 php:
-  - 7.1
+  - 7.3
   - 7.2
+  - 7.1
   - nightly
 
 env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.1-cli
+FROM php:7-cli
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
 

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "keboola/php-temp": "^1.0",
         "phpstan/phpstan-shim": "^0.9.1",
         "phpunit/phpunit": "^7.1",
-        "keboola/coding-standard": "^4.0"
+        "keboola/coding-standard": "^7.0.2"
     },
     "scripts": {
         "tests": "phpunit",

--- a/composer.json
+++ b/composer.json
@@ -29,10 +29,10 @@
         "php": "^7.1",
         "ext-json": "*",
         "monolog/monolog": "^1.23",
-        "symfony/config": "^4.0",
-        "symfony/filesystem": "^4.0",
-        "symfony/finder": "^4.0",
-        "symfony/serializer": "^4.0"
+        "symfony/config": "^4.2",
+        "symfony/filesystem": "^4.2",
+        "symfony/finder": "^4.2",
+        "symfony/serializer": "^4.2"
     },
     "require-dev": {
         "devedge/sami-github": "^1.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,7 +7,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="tests/bootstrap.php">
     <testsuite name="Tests">
         <directory>tests/</directory>

--- a/src/BaseComponent.php
+++ b/src/BaseComponent.php
@@ -150,7 +150,7 @@ class BaseComponent
         return $this->manifestManager;
     }
 
-    public function getLogger() : LoggerInterface
+    public function getLogger(): LoggerInterface
     {
         return $this->logger;
     }


### PR DESCRIPTION
Depends on #54 

Fixes:
* Keboola CS < 7 is not compatible with php7.3 → new CS required a fix
* latest phpunit deprecated syntaxCheck parameter
* symfony/config fixes 7.3 compatiblity in v4.1.4, changed required version to latest 4.2
* travis tests didn't test 7.3 (only nightly that is allowed to fail)
* local docker does not use "open" php version → changed to php:7-cli