### PR TITLE
Fix JsonHelper implementation and tests

### DIFF
--- a/src/JsonHelper.php
+++ b/src/JsonHelper.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Keboola\Component;
 
+use Keboola\Component\JsonHelper\JsonHelperException;
 use Symfony\Component\Filesystem\Exception\FileNotFoundException;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 
@@ -42,13 +43,13 @@ class JsonHelper
             mkdir($filePathDir, 0777, true);
         }
 
-        $result = file_put_contents(
+        $result = @file_put_contents(
             $filePath,
             self::encode($data, $formatted)
         );
 
         if ($result === false) {
-            throw new \ErrorException('Could not write to file "%s".');
+            throw new JsonHelperException(sprintf('Could not write to file "%s".', $filePath));
         }
     }
 }

--- a/src/JsonHelper/JsonHelperException.php
+++ b/src/JsonHelper/JsonHelperException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\Component\JsonHelper;
+
+use Exception;
+
+class JsonHelperException extends Exception
+{
+}

--- a/tests/JsonHelperTest.php
+++ b/tests/JsonHelperTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Keboola\Component\Tests;
 
 use Keboola\Component\JsonHelper;
+use Keboola\Component\JsonHelper\JsonHelperException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Exception\FileNotFoundException;
 use Symfony\Component\Serializer\Exception\NotEncodableValueException;
@@ -142,13 +143,13 @@ class JsonHelperTest extends TestCase
         rmdir(pathinfo($filePath, PATHINFO_DIRNAME));
     }
 
-    public function testWriteToProtectedDirectoryThrowsException(): void
+    public function testFailedWriteThrowsException(): void
     {
-        $filePath =  '/tmp.json';
+        $filePath =  'php://stdin';
         $array = ['key'];
 
-        $this->expectException(\ErrorException::class);
-        $this->expectExceptionMessageRegExp('~^file_put_contents(.*): failed to open stream: Permission denied$~');
+        $this->expectException(JsonHelperException::class);
+        $this->expectExceptionMessage('Could not write to file "php://stdin".');
         JsonHelper::writeFile($filePath, $array);
     }
 }


### PR DESCRIPTION
* without @ it won't proceed to exception, but will throw normal internal warning that is converted to error. 
* Exception was missing `sprintf`
* test tests correct exception message
* writing to root worked for me just fine - so the test failed (that's different in travis as it does not run as root)

Fixes: https://github.com/keboola/php-component/pull/52#issuecomment-449860813