### PR TITLE
Fix error handler for sync actions

### DIFF
--- a/src/Logger.php
+++ b/src/Logger.php
@@ -42,9 +42,18 @@ class Logger extends MonologLogger implements Logger\SyncActionLogging, Logger\A
         return $handler;
     }
 
+    public static function getSyncActionErrorHandler(): StreamHandler
+    {
+        $logHandler = new StreamHandler('php://stderr');
+        $logHandler->setBubble(false);
+        $logHandler->setLevel(MonologLogger::ERROR);
+        $logHandler->setFormatter(new LineFormatter("%message%\n"));
+        return $logHandler;
+    }
+
     public function setupSyncActionLogging(): void
     {
-        $this->setHandlers([]);
+        $this->setHandlers([self::getSyncActionErrorHandler()]);
     }
 
     public function setupAsyncActionLogging(): void


### PR DESCRIPTION
"ERROR" log level messages are output on stderr as simple messages, one
per line. This allows to use info and alert for component's internal uses.

Fixes https://github.com/keboola/looker-writer/issues/6