### PR TITLE
Fix Logger compatibility with monolog 2.X

### DIFF
--- a/src/Logger.php
+++ b/src/Logger.php
@@ -22,6 +22,11 @@ class Logger extends MonologLogger implements Logger\SyncActionLogging, Logger\A
     public function __construct()
     {
         parent::__construct('php-component');
+
+        // Add default logger to log errors in configuration, etc.
+        // It will be overwritten by calling setupSyncActionLogging/setupAsyncActionLogging
+        // from BaseComponent::initializeSyncActions
+        $this->pushHandler(new StreamHandler('php://stderr', static::DEBUG));
     }
 
     public static function getDefaultLogHandler(): StreamHandler

--- a/tests/Logger/LoggerTest.php
+++ b/tests/Logger/LoggerTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\Component\Tests\Logger;
+
+use Keboola\Component\Logger;
+use Monolog\Handler\StreamHandler;
+use PHPUnit\Framework\TestCase;
+
+class LoggerTest extends TestCase
+{
+    public function testDefaultHandler(): void
+    {
+        $logger = new Logger();
+        $logger->debug('test');
+
+        $handlers = $logger->getHandlers();
+        $this->assertCount(1, $handlers);
+        $this->assertInstanceOf(StreamHandler::class, $handlers[0]);
+
+        /** @var StreamHandler $streamHandler */
+        $streamHandler = $handlers[0];
+        $this->assertSame('php://stderr', $streamHandler->getUrl());
+        $this->assertSame(Logger::DEBUG, $streamHandler->getLevel());
+    }
+
+    public function testSetupSyncActionLogging(): void
+    {
+        $logger = new Logger();
+        $logger->debug('test');
+        $logger->setupSyncActionLogging();
+
+        $handlers = $logger->getHandlers();
+        $this->assertCount(1, $handlers);
+
+        /** @var StreamHandler $streamHandler */
+        $streamHandler = $handlers[0];
+        $this->assertSame('php://stderr', $streamHandler->getUrl());
+        $this->assertSame(Logger::ERROR, $streamHandler->getLevel());
+    }
+
+    public function testSetupAsyncActionLogging(): void
+    {
+        $logger = new Logger();
+        $logger->debug('test');
+        $logger->setupAsyncActionLogging();
+
+        $handlers = $logger->getHandlers();
+        $this->assertCount(3, $handlers);
+    }
+}


### PR DESCRIPTION
Changes:
- fix compatibility with `monolog: 2.X`
- monolog was updated in previous release from `1.X -> 2.X`: https://github.com/keboola/php-component/releases/tag/8.0.0
- in `monolog: 2.X` is BC break:
  -  https://github.com/Seldaek/monolog/blob/master/UPGRADE.md#200
  - `There is no more default handler configured on empty Logger instances, if you were relying on that you will not get any output anymore, make sure to configure the handler you need.`
  - Therefore is needed to set default logger in constructor of our `Logger` class