### PR TITLE
Column manifest options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ vendor/
 cache/
 docs/
 composer.lock
+.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Keboola PHP Component
 
-[![Build Status](https://travis-ci.org/keboola/php-component.svg?branch=master)](https://travis-ci.org/keboola/php-component)
+[![Build Status](https://travis-ci.com/keboola/php-component.svg?branch=master)](https://travis-ci.com/keboola/php-component)
 [![Code Climate](https://codeclimate.com/github/keboola/php-component/badges/gpa.svg)](https://codeclimate.com/github/keboola/php-component)
 
 General library for php component running in KBC. The library provides function related to [Docker Runner](https://github.com/keboola/docker-bundle).

--- a/src/Manifest/ManifestManager/Options/OutTableManifestOptions.php
+++ b/src/Manifest/ManifestManager/Options/OutTableManifestOptions.php
@@ -111,10 +111,10 @@ class OutTableManifestOptions
     }
 
     /**
-     * @param mixed[] $columnsMetadata
+     * @param mixed $columnsMetadata
      * @return OutTableManifestOptions
      */
-    public function setColumnMetadata(array $columnsMetadata): OutTableManifestOptions
+    public function setColumnMetadata($columnsMetadata): OutTableManifestOptions
     {
         foreach ($columnsMetadata as $columnName => $columnMetadata) {
             if (!is_array($columnMetadata)) {

--- a/tests/Config/BaseConfigTest.php
+++ b/tests/Config/BaseConfigTest.php
@@ -40,10 +40,18 @@ class BaseConfigTest extends TestCase
             }
         };
 
-        $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessage('The child node "requiredValue" at path "root.parameters" must be configured.');
-
-        new BaseConfig(['parameters' => []], $configDefinition);
+        try {
+            new BaseConfig(['parameters' => []], $configDefinition);
+            $this->fail('Expected "InvalidConfigurationException" exception.');
+        } catch (InvalidConfigurationException $e) {
+            $this->assertContains(
+                $e->getMessage(),
+                [
+                    'The child node "requiredValue" at path "root.parameters" must be configured.',
+                    'The child config "requiredValue" under "root.parameters" must be configured.',
+                ]
+            );
+        }
     }
 
     public function testStrictParametersCheck(): void
@@ -86,10 +94,19 @@ class BaseConfigTest extends TestCase
                 return $rootNode;
             }
         };
-        $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessage('The child node "requiredRootNode" at path "root" must be configured.');
 
-        new BaseConfig([], $configDefinition);
+        try {
+            new BaseConfig([], $configDefinition);
+            $this->fail('Expected "InvalidConfigurationException" exception.');
+        } catch (InvalidConfigurationException $e) {
+            $this->assertContains(
+                $e->getMessage(),
+                [
+                    'The child node "requiredRootNode" at path "root" must be configured.',
+                    'The child config "requiredRootNode" under "root" must be configured.',
+                ]
+            );
+        }
     }
 
     public function testIsForwardCompatible(): void

--- a/tests/Manifest/ManifestManager/Options/OutTableManifestOptionsTest.php
+++ b/tests/Manifest/ManifestManager/Options/OutTableManifestOptionsTest.php
@@ -58,7 +58,7 @@ class OutTableManifestOptionsTest extends TestCase
                             'value' => 'A different value',
                         ],
                     ],
-                    'column_metadata' => [
+                    'column_metadata' => (object) [
                         'column1' => [
                             [
                                 'key' => 'yet.another.key',
@@ -70,7 +70,7 @@ class OutTableManifestOptionsTest extends TestCase
                 (new OutTableManifestOptions())
                     ->setEnclosure('_')
                     ->setDelimiter('|')
-                    ->setColumnMetadata([
+                    ->setColumnMetadata((object) [
                         'column1' => [
                             [
                                 'value' => 'Some other value',

--- a/tests/Manifest/ManifestManager/Options/OutTableManifestOptionsTest.php
+++ b/tests/Manifest/ManifestManager/Options/OutTableManifestOptionsTest.php
@@ -59,6 +59,12 @@ class OutTableManifestOptionsTest extends TestCase
                         ],
                     ],
                     'column_metadata' => (object) [
+                        '123456' => [
+                            [
+                                'key' => 'int.column.name',
+                                'value' => 'Int column name',
+                            ],
+                        ],
                         'column1' => [
                             [
                                 'key' => 'yet.another.key',
@@ -71,6 +77,12 @@ class OutTableManifestOptionsTest extends TestCase
                     ->setEnclosure('_')
                     ->setDelimiter('|')
                     ->setColumnMetadata((object) [
+                        '123456' => [
+                            [
+                                'value' => 'Int column name',
+                                'key' => 'int.column.name',
+                            ],
+                        ],
                         'column1' => [
                             [
                                 'value' => 'Some other value',


### PR DESCRIPTION
Základní problém byl v tom že pokud do klíče pole se uloží číslo (přetypované na string) tak je v poli stejně jako int 
https://www.php.net/manual/en/function.array-keys.php

jedno z řešení je posílat column_metadata jako objekt (možná i vynuceně)

Jestli je to pole nebo object je pro json_encode jedno:
http://sandbox.onlinephpfunctions.com/code/3667ab12d2037d27c216c46227f9d08670a990b7