### PR TITLE
Log context for Application error in sync action

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,4 @@
 parameters:
     checkMissingIterableValueType: false
     ignoreErrors:
+        - '#Unreachable statement - code above always terminates#'

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -51,7 +51,7 @@ class Logger extends MonologLogger implements Logger\SyncActionLogging, Logger\A
         $logHandler = new StreamHandler('php://stderr');
         $logHandler->setBubble(false);
         $logHandler->setLevel(MonologLogger::CRITICAL);
-        $logHandler->setFormatter(new LineFormatter("%message% %context% %extra%\n"));
+        $logHandler->setFormatter(new LineFormatter("%message% %context% %extra%\n", null, false, true));
         return $logHandler;
     }
 

--- a/tests/Logger/LoggerTest.php
+++ b/tests/Logger/LoggerTest.php
@@ -43,6 +43,30 @@ class LoggerTest extends TestCase
         $streamHandler2 = $handlers[1];
         $this->assertSame('php://stderr', $streamHandler2->getUrl());
         $this->assertSame(Logger::ERROR, $streamHandler2->getLevel());
+
+        // Init streams (stream is created with first message)
+        $streamHandler1->handle(['level' => Logger::CRITICAL, 'message' => '', 'extra' => [], 'context' => []]);
+        $streamHandler2->handle(['level' => Logger::ERROR, 'message' => '', 'extra' => [], 'context' => []]);
+
+        // Connect tester (logger) to the streams
+        /** @var resource $stream1 */
+        $stream1 = $streamHandler1->getStream();
+        /** @var resource $stream2 */
+        $stream2 = $streamHandler2->getStream();
+        StreamTester::attach($stream1);
+        StreamTester::attach($stream2);
+
+        // Log some messages
+        $logger->info('Info!', ['context' => 'info']);
+        $logger->error('Error!', ['context' => 'error']);
+        $logger->critical('Critical!', ['context' => 'critical']);
+
+        // Critical (application error) message has context in sync action
+        $this->assertSame(
+            "Error!\n".
+            "Critical! {\"context\":\"critical\"} \n",
+            StreamTester::getContent()
+        );
     }
 
     public function testSetupAsyncActionLogging(): void

--- a/tests/Logger/LoggerTest.php
+++ b/tests/Logger/LoggerTest.php
@@ -32,12 +32,17 @@ class LoggerTest extends TestCase
         $logger->setupSyncActionLogging();
 
         $handlers = $logger->getHandlers();
-        $this->assertCount(1, $handlers);
+        $this->assertCount(2, $handlers);
 
-        /** @var StreamHandler $streamHandler */
-        $streamHandler = $handlers[0];
-        $this->assertSame('php://stderr', $streamHandler->getUrl());
-        $this->assertSame(Logger::ERROR, $streamHandler->getLevel());
+        /** @var StreamHandler $streamHandler1 */
+        $streamHandler1 = $handlers[0];
+        $this->assertSame('php://stderr', $streamHandler1->getUrl());
+        $this->assertSame(Logger::CRITICAL, $streamHandler1->getLevel());
+
+        /** @var StreamHandler $streamHandler2 */
+        $streamHandler2 = $handlers[1];
+        $this->assertSame('php://stderr', $streamHandler2->getUrl());
+        $this->assertSame(Logger::ERROR, $streamHandler2->getLevel());
     }
 
     public function testSetupAsyncActionLogging(): void

--- a/tests/Logger/StreamTester.php
+++ b/tests/Logger/StreamTester.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\Component\Tests\Logger;
+
+class StreamTester extends \php_user_filter
+{
+    /** @var string */
+    private static $content = '';
+
+    /**
+     * @param resource $stream
+     */
+    public static function attach($stream): void
+    {
+        @stream_filter_register('streamTester', self::class);
+        stream_filter_append($stream, 'streamTester');
+    }
+
+    public static function getContent(): string
+    {
+        return self::$content;
+    }
+
+    /**
+     * @param resource $in
+     * @param resource $out
+     * @param int $consumed
+     * @param bool $closing
+     * @return int
+     */
+    public function filter($in, $out, &$consumed, $closing): int
+    {
+        while ($bucket = stream_bucket_make_writeable($in)) {
+            /** @var \stdClass $bucket */
+            self::$content .= $bucket->data;
+            $consumed += $bucket->datalen;
+            stream_bucket_append($out, $bucket);
+        }
+        return PSFS_PASS_ON;
+    }
+}


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/COM-621

- Testujem SCD code pattern v DEV/PROD mode.
- Ked kliknem na `Generate` tak mi sync akcia spadne, no chyba tam `context` (riadok a trieda), kde je problem: `failed: (2) Keboola\\StorageApi\\ClientException:Not implemented` 
- Sync akcie sa loguju specialne, ... loguje sa iba vazna chyba, exit code 1, 2, ... lebo v pripade uspechu ide na vystup JSON -> nic sa neloguje.
- Pri sync akcii sa teraz loguje iba `message`, kedze ta je zobrazena uzivatelovi, pokial exit code=1
- No v pripade application exception potrebujeme zalogovat aj `context`, inak to nevieme odladit.

Takto vyzera vzorovy `run.php` v komponente:
https://github.com/keboola/component-generator/blob/ab86d61de6d243580be002647f779aee22af58be/templates/php-component/src/run.php#L16-L30

```
} catch (UserException $e) {
    $logger->error($e->getMessage());
    exit(1);
} catch (\Throwable $e) {
    $logger->critical(
        get_class($e) . ':' . $e->getMessage(),
        [
            'errFile' => $e->getFile(),
            'errLine' => $e->getLine(),
            'errCode' => $e->getCode(),
            'errTrace' => $e->getTraceAsString(),
            'errPrevious' => is_object($e->getPrevious()) ? get_class($e->getPrevious()) : '',
        ]
    );
    exit(2);
````

Teda:
- pri `user error` sa vola `->error` log handler, ktory zostava bez zmeny.
- pri `application error` sa vola `->critical` error handler, kde sa teraz bude logovat aj `context`.

Narazil som na tento problem uz viac krat, tak to chcem vyriesit systemovo.