### PR TITLE
Fix up metadata normalizing in legacy serializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # Keboola PHP Component
 
-[![Build Status](https://travis-ci.com/keboola/php-component.svg?branch=master)](https://travis-ci.com/keboola/php-component)
-[![Code Climate](https://codeclimate.com/github/keboola/php-component/badges/gpa.svg)](https://codeclimate.com/github/keboola/php-component)
-
 General library for php component running in KBC. The library provides function related to [Docker Runner](https://github.com/keboola/docker-bundle).
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ class Component extends \Keboola\Component\BaseComponent
             'data.csv',
             (new OutTableManifestOptions())
                 ->setPrimaryKeyColumns(['id'])
-                ->setDestination('out.report')
+                ->setDestination('out.report'),
+            true // legacy manifest format flag
         );
     }
 

--- a/tests/Manifest/ManifestManagerTest.php
+++ b/tests/Manifest/ManifestManagerTest.php
@@ -103,6 +103,44 @@ class ManifestManagerTest extends TestCase
                 'id',
                 'number',
             ],
+            'column_metadata' => [
+                'id' => [
+                    [
+                        'key' => 'KBC.datatype.nullable',
+                        'value' => true,
+                    ],
+                ],
+                'number' => [
+                    [
+                        'key' => 'KBC.datatype.nullable',
+                        'value' => true,
+                    ],
+                ],
+                'name' => [
+                    [
+                        'key' => 'KBC.datatype.nullable',
+                        'value' => true,
+                    ],
+                ],
+                'description' => [
+                    [
+                        'key' => 'KBC.datatype.nullable',
+                        'value' => true,
+                    ],
+                ],
+                'created_at' => [
+                    [
+                        'key' => 'KBC.datatype.nullable',
+                        'value' => true,
+                    ],
+                ],
+                'updated_at' => [
+                    [
+                        'key' => 'KBC.datatype.nullable',
+                        'value' => true,
+                    ],
+                ],
+            ],
         ];
 
         $this->assertSame($expectedManifest, $manager->getTableManifest('people.csv')->toArray());
@@ -139,6 +177,26 @@ class ManifestManagerTest extends TestCase
             'primary_key' => [
                 'id',
                 'number',
+            ],
+            'column_metadata' => [
+                'id' => [
+                    [
+                        'key' => 'KBC.datatype.nullable',
+                        'value' => true,
+                    ],
+                ],
+                'number' => [
+                    [
+                        'key' => 'KBC.datatype.nullable',
+                        'value' => true,
+                    ],
+                ],
+                'name' => [
+                    [
+                        'key' => 'KBC.datatype.nullable',
+                        'value' => true,
+                    ],
+                ],
             ],
         ];
 
@@ -430,8 +488,56 @@ class ManifestManagerTest extends TestCase
             'column_metadata' => [
                 'id' => [
                     [
+                        'key' => 'KBC.datatype.nullable',
+                        'value' => false,
+                    ],
+                    [
+                        'key' => 'KBC.description',
+                        'value' => 'This is a primary key',
+                    ],
+                    [
+                        'key' => 'KBC.datatype.basetype',
+                        'value' => 'INTEGER',
+                    ],
+                    [
+                        'key' => 'KBC.datatype.length',
+                        'value' => '11',
+                    ],
+                    [
+                        'key' => 'KBC.datatype.default',
+                        'value' => '123',
+                    ],
+                    [
                         'key' => 'yet.another.key',
                         'value' => 'Some other value',
+                    ],
+                ],
+                'number' => [
+                    [
+                        'key' => 'KBC.datatype.nullable',
+                        'value' => true,
+                    ],
+                    [
+                        'key' => 'KBC.datatype.basetype',
+                        'value' => 'VARCHAR',
+                    ],
+                    [
+                        'key' => 'KBC.datatype.length',
+                        'value' => '255',
+                    ],
+                ],
+                'other_column' => [
+                    [
+                        'key' => 'KBC.datatype.nullable',
+                        'value' => true,
+                    ],
+                    [
+                        'key' => 'KBC.datatype.basetype',
+                        'value' => 'VARCHAR',
+                    ],
+                    [
+                        'key' => 'KBC.datatype.length',
+                        'value' => '255',
                     ],
                 ],
             ],


### PR DESCRIPTION
Tohle už by mělo být snad poslední fix, přidával jsem testy na ten legacy formát do db-extractor-common a narazil jsem tam na chybějící metadata.