### PR TITLE
Deduplicate metadata in legacy structure

### DIFF
--- a/src/Manifest/ManifestManager/Options/OutTable/Serializer/LegacyManifestNormalizer.php
+++ b/src/Manifest/ManifestManager/Options/OutTable/Serializer/LegacyManifestNormalizer.php
@@ -72,6 +72,7 @@ class LegacyManifestNormalizer implements NormalizerInterface, DenormalizerInter
 
                 $this->normalizeDataTypes($schema, $columnMetadata);
                 $this->normalizeColumnMetadata($schema, $columnMetadata);
+                $this->deduplicateMetadata($columnMetadata);
 
                 if (!empty($columnMetadata)) {
                     $data['column_metadata'][$schema->getName()] = $columnMetadata;
@@ -247,5 +248,24 @@ class LegacyManifestNormalizer implements NormalizerInterface, DenormalizerInter
     public function supportsDenormalization($data, $type, $format = null): bool
     {
         return $type === ManifestOptions::class;
+    }
+
+    private function deduplicateMetadata(array &$columnMetadata): void
+    {
+        $columnMetadata = array_values(array_reduce(
+            $columnMetadata,
+            /**
+             * @param array<string, array<string, mixed>> $carry
+             * @param array<string, mixed> $item
+             * @return array<string, array<string, mixed>>
+             */
+            function (array $carry, array $item): array {
+                if (isset($item['key']) && !isset($carry[$item['key']])) {
+                    $carry[$item['key']] = $item;
+                }
+                return $carry;
+            },
+            [],
+        ));
     }
 }

--- a/tests/Manifest/ManifestManagerTest.php
+++ b/tests/Manifest/ManifestManagerTest.php
@@ -361,6 +361,10 @@ class ManifestManagerTest extends TestCase
                                 'key' => 'yet.another.key',
                                 'value' => 'Some other value',
                             ],
+                            [
+                                'key' => 'yet.another.key', //duplicated key should be removed
+                                'value' => 'Some other value',
+                            ],
                         ],
                     ])
                     ->setDestination('my.table')


### PR DESCRIPTION
Zjistil jsem, že když tam pak mám třeba length dvakrát (jednou u snowflake a jednou u base), tak v legacy formátu manifestu je to pak duplicitně. 