### PR TITLE
fix: allow to reset legacyPrimaryKeys by adding null type to setter

### DIFF
--- a/src/Manifest/ManifestManager/Options/OutTable/ManifestOptions.php
+++ b/src/Manifest/ManifestManager/Options/OutTable/ManifestOptions.php
@@ -387,7 +387,7 @@ class ManifestOptions
         return $this;
     }
 
-    public function setLegacyPrimaryKeys(array $primaryKey): ManifestOptions
+    public function setLegacyPrimaryKeys(?array $primaryKey): ManifestOptions
     {
         $this->legacyPrimaryKeys = $primaryKey;
         return $this;


### PR DESCRIPTION
Pokud dostane create-manifest-processor na vstupu manifest s PK bez vyjmenovaných columns, které tam pak doplní je potřeba tu property s legacy PKs vyresetovat.

JIRA: https://keboola.atlassian.net/browse/PST-2072
Ticket: https://keboola.atlassian.net/browse/SUPPORT-7847?atlOrigin=eyJpIjoiOWE1ODgyOTM4MGI4NDc5YjgzZmEyNTYyN2U2YWZjNzYiLCJwIjoiamlyYS1zbGFjay1pbnQifQ