### PR TITLE
Allow Symfony 7.*, use psr/log:^3.0 with newer Monolog

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,11 +15,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        phpVersion: [8.1, 8.2, 8.3, 8.4]
+        phpVersion: [8.2, 8.3, 8.4]
         symfonyVersion: ["5.4.*", "6.4.*", "7.2.*"]
-        exclude:
-          - phpVersion: 8.1
-            symfonyVersion: 7.2.*
 
     steps:
       -

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,8 +15,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        phpVersion: [8.1, 8.2, 8.3]
-        symfonyVersion: ["5.4.*", "6.1.*"]
+        phpVersion: [8.1, 8.2, 8.3, 8.4]
+        symfonyVersion: ["5.4.*", "6.4.*", "7.2.*"]
+        exclude:
+          - phpVersion: 8.1
+            symfonyVersion: 7.2.*
 
     steps:
       -

--- a/composer.json
+++ b/composer.json
@@ -29,19 +29,19 @@
         "php": ">=8.1",
         "ext-json": "*",
         "keboola/common-exceptions": "^1.2",
-        "monolog/monolog": "^2.3",
-        "symfony/config": "^5.4|^6.0",
-        "symfony/filesystem": "^5.4|^6.0",
-        "symfony/finder": "^5.4|^6.0",
-        "symfony/property-access": "^5.4|^6.0",
-        "symfony/serializer": "^5.4|^6.0"
+        "monolog/monolog": "^3.0",
+        "symfony/config": "^5.4|^6.0|^7.0",
+        "symfony/filesystem": "^5.4|^6.0|^7.0",
+        "symfony/finder": "^5.4|^6.0|^7.0",
+        "symfony/property-access": "^5.4|^6.0|^7.0",
+        "symfony/serializer": "^5.4|^6.0|^7.0"
     },
     "require-dev": {
-        "devedge/sami-github": "^1.0",
-        "keboola/coding-standard": "^15.0",
-        "keboola/php-temp": "^2.0",
-        "phpstan/phpstan": "^1.4",
-        "phpunit/phpunit": "^9.5"
+        "devedge/sami-github": "^1.0.6",
+        "keboola/coding-standard": "^15.0.1",
+        "keboola/php-temp": "^2.0.1",
+        "phpstan/phpstan": "^1.12.24",
+        "phpunit/phpunit": "^9.6.22"
     },
     "scripts": {
         "tests": "phpunit",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         }
     },
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.2",
         "ext-json": "*",
         "keboola/common-exceptions": "^1.2",
         "monolog/monolog": "^3.0",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,6 @@
 parameters:
     ignoreErrors:
-        -
-        			identifier: missingType.iterableValue
+        - identifier: missingType.iterableValue
         - '#Argument of an invalid type array\|object supplied for foreach, only iterables are supported.#'
+        - message: '#Class Keboola\\Component\\Logger extends @final class Monolog\\Logger.#'
+          reportUnmatched: false

--- a/src/BaseComponent.php
+++ b/src/BaseComponent.php
@@ -63,7 +63,7 @@ class BaseComponent
         error_reporting(E_ALL);
 
         set_error_handler(function (int $errno, string $errstr, string $errfile, int $errline): bool {
-            if (!(error_reporting() & $errno) || $errno === E_USER_DEPRECATED) {
+            if (!(error_reporting() & $errno) || $errno === E_USER_DEPRECATED || $errno === E_DEPRECATED) {
                 // respect error_reporting() level
                 // libraries used in custom components may emit notices that cannot be fixed
                 return false;

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -7,6 +7,7 @@ namespace Keboola\Component;
 use Keboola\Component\Config\BaseConfig;
 use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\StreamHandler;
+use Monolog\Level;
 use Monolog\Logger as MonologLogger;
 
 class Logger extends MonologLogger implements Logger\SyncActionLogging, Logger\AsyncActionLogging
@@ -15,7 +16,7 @@ class Logger extends MonologLogger implements Logger\SyncActionLogging, Logger\A
     {
         $errorHandler = new StreamHandler('php://stderr');
         $errorHandler->setBubble(false);
-        $errorHandler->setLevel(MonologLogger::WARNING);
+        $errorHandler->setLevel(Level::Warning);
         $errorHandler->setFormatter(new LineFormatter("%message%\n"));
         return $errorHandler;
     }
@@ -24,7 +25,7 @@ class Logger extends MonologLogger implements Logger\SyncActionLogging, Logger\A
     {
         $logHandler = new StreamHandler('php://stdout');
         $logHandler->setBubble(false);
-        $logHandler->setLevel(MonologLogger::INFO);
+        $logHandler->setLevel(Level::Info);
         $logHandler->setFormatter(new LineFormatter("%message%\n"));
         return $logHandler;
     }
@@ -33,7 +34,7 @@ class Logger extends MonologLogger implements Logger\SyncActionLogging, Logger\A
     {
         $handler = new StreamHandler('php://stderr');
         $handler->setBubble(false);
-        $handler->setLevel(MonologLogger::CRITICAL);
+        $handler->setLevel(Level::Critical);
         $handler->setFormatter(new LineFormatter("[%datetime%] %level_name%: %message% %context% %extra%\n"));
         return $handler;
     }
@@ -42,7 +43,7 @@ class Logger extends MonologLogger implements Logger\SyncActionLogging, Logger\A
     {
         $handler = new StreamHandler('php://stdout');
         $handler->setBubble(false);
-        $handler->setLevel(MonologLogger::DEBUG);
+        $handler->setLevel(Level::Debug);
         $handler->setFormatter(new LineFormatter("[%datetime%] %level_name%: %message% %context% %extra%\n"));
         return $handler;
     }
@@ -51,7 +52,7 @@ class Logger extends MonologLogger implements Logger\SyncActionLogging, Logger\A
     {
         $logHandler = new StreamHandler('php://stderr');
         $logHandler->setBubble(false);
-        $logHandler->setLevel(MonologLogger::ERROR);
+        $logHandler->setLevel(Level::Error);
         $logHandler->setFormatter(new LineFormatter("%message%\n"));
         return $logHandler;
     }
@@ -60,7 +61,7 @@ class Logger extends MonologLogger implements Logger\SyncActionLogging, Logger\A
     {
         $logHandler = new StreamHandler('php://stderr');
         $logHandler->setBubble(false);
-        $logHandler->setLevel(MonologLogger::CRITICAL);
+        $logHandler->setLevel(Level::Critical);
         $logHandler->setFormatter(new LineFormatter("%message% %context% %extra%\n", null, false, true));
         return $logHandler;
     }
@@ -69,7 +70,7 @@ class Logger extends MonologLogger implements Logger\SyncActionLogging, Logger\A
     {
         $logHandler = new StreamHandler('php://stdout');
         $logHandler->setBubble(false);
-        $logHandler->setLevel(MonologLogger::DEBUG);
+        $logHandler->setLevel(Level::Debug);
         $logHandler->setFormatter(new LineFormatter("[%datetime%] %level_name%: %message% %context% %extra%\n"));
         return $logHandler;
     }

--- a/src/Manifest/ManifestManager/Options/OutTable/Serializer/LegacyManifestNormalizer.php
+++ b/src/Manifest/ManifestManager/Options/OutTable/Serializer/LegacyManifestNormalizer.php
@@ -13,6 +13,13 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class LegacyManifestNormalizer implements NormalizerInterface, DenormalizerInterface
 {
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            '*' => true,
+        ];
+    }
+
     public function normalize($object, ?string $format = null, array $context = []): array
     {
         $data = [];
@@ -263,12 +270,12 @@ class LegacyManifestNormalizer implements NormalizerInterface, DenormalizerInter
         }
     }
 
-    public function supportsNormalization($data, $format = null): bool
+    public function supportsNormalization($data, $format = null, array $context = []): bool
     {
         return $data instanceof ManifestOptions;
     }
 
-    public function supportsDenormalization($data, $type, $format = null): bool
+    public function supportsDenormalization($data, $type, $format = null, array $context = []): bool
     {
         return $type === ManifestOptions::class;
     }

--- a/tests/Logger/LoggerTest.php
+++ b/tests/Logger/LoggerTest.php
@@ -8,6 +8,8 @@ use DateTimeImmutable;
 use Keboola\Component\Config\BaseConfig;
 use Keboola\Component\Logger;
 use Monolog\Handler\StreamHandler;
+use Monolog\Level;
+use Monolog\LogRecord;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 
@@ -25,7 +27,7 @@ class LoggerTest extends TestCase
         /** @var StreamHandler $streamHandler */
         $streamHandler = $handlers[0];
         $this->assertSame('php://stderr', $streamHandler->getUrl());
-        $this->assertSame(Logger::DEBUG, $streamHandler->getLevel());
+        $this->assertSame(Level::Debug, $streamHandler->getLevel());
     }
 
     public function testSetupSyncActionLogging(): void
@@ -40,32 +42,30 @@ class LoggerTest extends TestCase
         /** @var StreamHandler $streamHandler1 */
         $streamHandler1 = $handlers[0];
         $this->assertSame('php://stderr', $streamHandler1->getUrl());
-        $this->assertSame(Logger::CRITICAL, $streamHandler1->getLevel());
+        $this->assertSame(Level::Critical, $streamHandler1->getLevel());
 
         /** @var StreamHandler $streamHandler2 */
         $streamHandler2 = $handlers[1];
         $this->assertSame('php://stderr', $streamHandler2->getUrl());
-        $this->assertSame(Logger::ERROR, $streamHandler2->getLevel());
+        $this->assertSame(Level::Error, $streamHandler2->getLevel());
 
         // Init streams (stream is created with first message)
-        $streamHandler1->handle([
-            'level' => Logger::CRITICAL,
-            'message' => '',
-            'extra' => [],
-            'context' => [],
-            'datetime' => new DateTimeImmutable(),
-            'channel' => '',
-            'level_name' => Logger::getLevelName(Logger::CRITICAL),
-        ]);
-        $streamHandler2->handle([
-            'level' => Logger::ERROR,
-            'message' => '',
-            'extra' => [],
-            'context' => [],
-            'datetime' => new DateTimeImmutable(),
-            'channel' => '',
-            'level_name' => Logger::getLevelName(Logger::ERROR),
-        ]);
+        $streamHandler1->handle(new LogRecord(
+            datetime: new DateTimeImmutable(),
+            channel: '',
+            level: Level::Critical,
+            message: '',
+            context: [],
+            extra: [],
+        ));
+        $streamHandler2->handle(new LogRecord(
+            datetime: new DateTimeImmutable(),
+            channel: '',
+            level: Level::Error,
+            message: '',
+            context: [],
+            extra: [],
+        ));
 
         // Connect tester (logger) to the streams
         /** @var resource $stream1 */
@@ -143,10 +143,10 @@ class LoggerTest extends TestCase
             StreamTester::getContent(),
         );
 
-        $this->assertSame(Logger::CRITICAL, $handlerCritical->getLevel());
-        $this->assertSame(Logger::WARNING, $handlerError->getLevel());
-        $this->assertSame(Logger::INFO, $handlerLog->getLevel());
-        $this->assertSame(Logger::DEBUG, $handlerDebug->getLevel());
+        $this->assertSame(Level::Critical, $handlerCritical->getLevel());
+        $this->assertSame(Level::Warning, $handlerError->getLevel());
+        $this->assertSame(Level::Info, $handlerLog->getLevel());
+        $this->assertSame(Level::Debug, $handlerDebug->getLevel());
 
         $this->assertSame('php://stderr', $handlerCritical->getUrl());
         $this->assertSame('php://stderr', $handlerError->getUrl());

--- a/tests/Logger/StreamTester.php
+++ b/tests/Logger/StreamTester.php
@@ -33,7 +33,6 @@ class StreamTester extends php_user_filter
     public function filter($in, $out, &$consumed, $closing): int
     {
         while ($bucket = stream_bucket_make_writeable($in)) {
-            /** @var \stdClass $bucket */
             self::$content .= $bucket->data;
             $consumed += $bucket->datalen;
             stream_bucket_append($out, $bucket);


### PR DESCRIPTION
* uprava defaultniho error handlingu, aby nekonvertoval `E_DEPRECATED` na `ErrorException` - v PHP 8.4 se toho objevilo celkem dost
  * tady jsem zaroven pridal upravu `error_reporting` do sync akci, aby se tam deprecation vubec nereportovalo, protoze by to rozbilo output sync akce
* update na `psr/log: ^3.0` (co umozni instalacni `monolog/monolog: ^3.0`), nektery libs (napr. GCP SDK) uz to zacinaji vyzadovat
* povoleni Symfony 7.x

Chtel jsem to udelat +/- kompatibilni, ale kdyz zpetne vidim soupis zmen, asi bych to vydal jako major verzi?